### PR TITLE
@nuxt/content support: Test if markdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,9 @@ const windicssModule: Module<UserOptions> = function(moduleOptions) {
   if (nuxtOptions.dev) {
     // @nuxt/content support, only required in dev
     nuxt.hook('content:file:beforeParse', async(md: File) => {
+      // only modify .md files
+      if (md.extension !== '.md') return
+      
       // instead of rebuilding the entire windi virtual module we will just insert our styles into the md file
       const utils = createUtils({
         ...windiConfig,


### PR DESCRIPTION
By appending a style string to any files other than markdown causes the build to fail.

https://github.com/windicss/nuxt-windicss-module/blob/13e0659bac61933435548c7e3be380598f6fc01b/src/index.ts#L116-L128

Fixes Issue #91